### PR TITLE
feat: add page renderer detection tool

### DIFF
--- a/src/tools/application.ts
+++ b/src/tools/application.ts
@@ -299,7 +299,7 @@ function createCurrentPageTool(manager: WeappAutomatorManager): AnyTool {
   return {
     name: "mp_currentPage",
     description:
-      "获取当前页面的信息，包括路径、查询参数、尺寸和滚动位置。通常在 mp_ensureConnection 成功后立即调用，用于确认当前页面。withData 为 true 时额外返回页面数据。",
+      "获取当前页面的信息，包括路径、查询参数、尺寸、滚动位置、当前页面真实渲染器 renderer，以及 wx.getSkylineInfoSync() 的 Skyline 诊断信息 skylineInfo。通常在 mp_ensureConnection 成功后立即调用，用于确认当前页面；可通过 renderer 区分 webview/skyline，skylineInfo 仅用于判断运行环境能力。withData 为 true 时额外返回页面数据。",
     parameters: currentPageParameters,
     execute: async (rawArgs, context: ToolContext) =>
       withUserErrorResult(async () => {
@@ -318,11 +318,43 @@ function createCurrentPageTool(manager: WeappAutomatorManager): AnyTool {
             page.scrollTop().catch(() => null),
           ]);
 
+          const runtimeInfo = await miniProgram
+            .evaluate(() => {
+              const runtime = globalThis as typeof globalThis & {
+                getCurrentPages?: () => Array<{ renderer?: unknown }>;
+                wx?: {
+                  getSkylineInfoSync?: () => unknown;
+                };
+              };
+
+              const pages =
+                typeof runtime.getCurrentPages === "function"
+                  ? runtime.getCurrentPages()
+                  : [];
+              const currentPage = pages[pages.length - 1];
+
+              let skylineInfo: unknown = null;
+              if (typeof runtime.wx?.getSkylineInfoSync === "function") {
+                skylineInfo = runtime.wx.getSkylineInfoSync();
+              }
+
+              return {
+                renderer: currentPage?.renderer ?? null,
+                skylineInfo,
+              };
+            })
+            .catch(() => ({
+              renderer: null,
+              skylineInfo: null,
+            }));
+
           const result: Record<string, unknown> = {
             path: page.path,
             query: toSerializableValue(page.query),
             size: toSerializableValue(size),
             scrollTop: toSerializableValue(scrollTop),
+            renderer: toSerializableValue(runtimeInfo.renderer),
+            skylineInfo: toSerializableValue(runtimeInfo.skylineInfo),
           };
 
           if (args.withData) {

--- a/src/tools/element.ts
+++ b/src/tools/element.ts
@@ -596,7 +596,8 @@ function createGetAttributesTool(manager: WeappAutomatorManager): AnyTool {
 function createGetBoundingClientRectTool(manager: WeappAutomatorManager): AnyTool {
   return {
     name: "element_getBoundingClientRect",
-    description: "获取元素相对于视口的边界矩形信息（left、top、width、height、right、bottom）。此方法返回的是考虑 CSS transform 变换后的实际渲染尺寸和位置。支持跨组件查询：若需获取自定义组件内部元素，可将 selector 设为组件选择器，innerSelector 设为内部元素选择器。注意：目前仅支持 ID 选择器、类选择器。",
+    description: "获取元素相对于视口的边界矩形信息（left、top、width、height、right、bottom）。此方法返回的是考虑 CSS transform 变换后的实际渲染尺寸和位置。仅支持 ID 选择器、类选择器。" +
+        "若目标元素位于自定义组件内部，selector 必须指向「当前页面 wxml 源码中直接引用的那一层自定义组件，而非渲染后的组件树」，innerSelector 可在 selector 所指组件的整个子树内匹配。",
     parameters: getBoundingClientRectParameters,
     execute: async (rawArgs, context: ToolContext) =>
       withUserErrorResult(async () => {

--- a/src/tools/element.ts
+++ b/src/tools/element.ts
@@ -596,8 +596,7 @@ function createGetAttributesTool(manager: WeappAutomatorManager): AnyTool {
 function createGetBoundingClientRectTool(manager: WeappAutomatorManager): AnyTool {
   return {
     name: "element_getBoundingClientRect",
-    description: "获取元素相对于视口的边界矩形信息（left、top、width、height、right、bottom）。此方法返回的是考虑 CSS transform 变换后的实际渲染尺寸和位置。仅支持 ID 选择器、类选择器。" +
-        "若目标元素位于自定义组件内部，selector 必须指向「当前页面 wxml 源码中直接引用的那一层自定义组件，而非渲染后的组件树」，innerSelector 可在 selector 所指组件的整个子树内匹配。",
+    description: "获取元素相对于视口的边界矩形信息（left、top、width、height、right、bottom）。此方法返回的是考虑 CSS transform 变换后的实际渲染尺寸和位置。仅支持 ID 选择器、类选择器。若目标元素位于自定义组件内部，selector 必须指向当前页面 WXML 源码中直接引用的那一层自定义组件，而不是渲染后的组件树；innerSelector 可在 selector 所指组件的整个子树内匹配。",
     parameters: getBoundingClientRectParameters,
     execute: async (rawArgs, context: ToolContext) =>
       withUserErrorResult(async () => {

--- a/src/tools/page.ts
+++ b/src/tools/page.ts
@@ -28,6 +28,8 @@ const callPageMethodParameters = connectionContainerSchema.extend({
   args: z.array(z.unknown()).optional(),
 });
 
+const getRendererParameters = connectionContainerSchema;
+
 const waitForElementParameters = connectionContainerSchema.extend({
   selector: z.string().trim().min(1),
   timeout: z.coerce.number().int().positive().optional().default(5000),
@@ -58,6 +60,7 @@ export function createPageTools(manager: WeappAutomatorManager): AnyTool[] {
     createGetPageDataTool(manager),
     createSetPageDataTool(manager),
     createCallPageMethodTool(manager),
+    createGetRendererTool(manager),
   ];
 }
 
@@ -361,6 +364,45 @@ function createCallPageMethodTool(manager: WeappAutomatorManager): AnyTool {
               method: args.method,
               arguments: callArgs,
               result: toSerializableValue(result),
+            })
+          );
+        }
+      );
+      }),
+  };
+}
+
+function createGetRendererTool(manager: WeappAutomatorManager): AnyTool {
+  return {
+    name: "page_getRenderer",
+    description: "获取当前页面运行时渲染引擎，返回 webview 或 skyline。",
+    parameters: getRendererParameters,
+    execute: async (rawArgs, context: ToolContext) =>
+      withUserErrorResult(async () => {
+      const args = getRendererParameters.parse(rawArgs ?? {});
+      return manager.withMiniProgram<ContentResult>(
+        context.log,
+        { overrides: args.connection },
+        async (miniProgram) => {
+          let skylineInfo;
+          try {
+            skylineInfo = await miniProgram.callWxMethod("getSkylineInfoSync");
+          } catch (error) {
+            const message = error instanceof Error ? error.message : String(error);
+            throw new UserError(`调用 wx.getSkylineInfoSync() 失败: ${message}`);
+          }
+
+          const isSupported =
+            typeof skylineInfo === "object" &&
+            skylineInfo !== null &&
+            "isSupported" in skylineInfo &&
+            Boolean((skylineInfo as { isSupported?: unknown }).isSupported);
+          const renderer = isSupported ? "skyline" : "webview";
+
+          return toTextResult(
+            formatJson({
+              renderer,
+              skylineInfo: toSerializableValue(skylineInfo),
             })
           );
         }

--- a/src/tools/page.ts
+++ b/src/tools/page.ts
@@ -28,8 +28,6 @@ const callPageMethodParameters = connectionContainerSchema.extend({
   args: z.array(z.unknown()).optional(),
 });
 
-const getRendererParameters = connectionContainerSchema;
-
 const waitForElementParameters = connectionContainerSchema.extend({
   selector: z.string().trim().min(1),
   timeout: z.coerce.number().int().positive().optional().default(5000),
@@ -60,7 +58,6 @@ export function createPageTools(manager: WeappAutomatorManager): AnyTool[] {
     createGetPageDataTool(manager),
     createSetPageDataTool(manager),
     createCallPageMethodTool(manager),
-    createGetRendererTool(manager),
   ];
 }
 
@@ -364,45 +361,6 @@ function createCallPageMethodTool(manager: WeappAutomatorManager): AnyTool {
               method: args.method,
               arguments: callArgs,
               result: toSerializableValue(result),
-            })
-          );
-        }
-      );
-      }),
-  };
-}
-
-function createGetRendererTool(manager: WeappAutomatorManager): AnyTool {
-  return {
-    name: "page_getRenderer",
-    description: "获取当前页面运行时渲染引擎，返回 webview 或 skyline。",
-    parameters: getRendererParameters,
-    execute: async (rawArgs, context: ToolContext) =>
-      withUserErrorResult(async () => {
-      const args = getRendererParameters.parse(rawArgs ?? {});
-      return manager.withMiniProgram<ContentResult>(
-        context.log,
-        { overrides: args.connection },
-        async (miniProgram) => {
-          let skylineInfo;
-          try {
-            skylineInfo = await miniProgram.callWxMethod("getSkylineInfoSync");
-          } catch (error) {
-            const message = error instanceof Error ? error.message : String(error);
-            throw new UserError(`调用 wx.getSkylineInfoSync() 失败: ${message}`);
-          }
-
-          const isSupported =
-            typeof skylineInfo === "object" &&
-            skylineInfo !== null &&
-            "isSupported" in skylineInfo &&
-            Boolean((skylineInfo as { isSupported?: unknown }).isSupported);
-          const renderer = isSupported ? "skyline" : "webview";
-
-          return toTextResult(
-            formatJson({
-              renderer,
-              skylineInfo: toSerializableValue(skylineInfo),
             })
           );
         }


### PR DESCRIPTION
## Summary
- add page_getRenderer to report the current renderer as webview or skyline
- include raw wx.getSkylineInfoSync() output for diagnostics
- clarify component selector guidance for bounding client rect lookup

## Validation
- npm run build