### PR TITLE
feat: add XPath page query tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ npx weapp-dev-mcp
       "mcp__weapp-dev-mcp__mp_setDefaultProject",
       "mcp__weapp-dev-mcp__page_getElement",
       "mcp__weapp-dev-mcp__page_getElements",
+      "mcp__weapp-dev-mcp__page_getElementByXpath",
+      "mcp__weapp-dev-mcp__page_getElementsByXpath",
       "mcp__weapp-dev-mcp__page_waitElement",
       "mcp__weapp-dev-mcp__page_waitTimeout",
       "mcp__weapp-dev-mcp__page_getData",
@@ -175,6 +177,8 @@ npx weapp-dev-mcp
 
 - `page_getElement` – 通过选择器获取页面元素，返回元素摘要信息（tagName、text、value、size、offset）；设置 `withWxml: true` 可额外返回完整 outerWxml；**支持 [index=N] 语法选择第 N 个元素**
 - `page_getElements` – 通过选择器获取页面元素数组，返回每个元素的摘要信息；设置 `withWxml: true` 可额外返回每个元素的完整 outerWxml；**支持 [index=N] 语法**
+- `page_getElementByXpath` – 通过 XPath 获取页面第一个匹配元素，适合按文本、属性、层级关系、ancestor/following 等表达式定位；设置 `withWxml: true` 可额外返回完整 outerWxml
+- `page_getElementsByXpath` – 通过 XPath 获取页面匹配元素数组，返回每个元素的摘要信息；设置 `withWxml: true` 可额外返回每个元素的完整 outerWxml
 - `page_waitElement` – 等待元素出现在页面上（⚠️ 不适用于自定义组件内部元素）；**支持 [index=N] 语法；增加超时和重试间隔参数**
 - `page_waitTimeout` – 等待指定的毫秒数
 - `page_getData` – 获取当前页面的数据对象，可指定路径（**支持嵌套路径如 'user.name'**）

--- a/src/prompts.ts
+++ b/src/prompts.ts
@@ -41,7 +41,7 @@ export function createPrompts(): WeappPrompt[] {
           "After connection succeeds:",
           "- Call mp_currentPage.",
           "- Call mp_screenshot.",
-          "- If needed, use page_getElements or page_getElement to inspect the UI tree.",
+          "- If needed, use page_getElements/page_getElement or page_getElementsByXpath/page_getElementByXpath to inspect the UI tree.",
           `- Report the current page path and whether the requested home-page UI is visible.${target}`,
           "",
           "If connection fails twice, stop and report the exact MCP error instead of looping.",

--- a/src/tools/page.ts
+++ b/src/tools/page.ts
@@ -49,10 +49,22 @@ const getElementsParameters = connectionContainerSchema.extend({
   withWxml: z.boolean().optional().default(false),
 });
 
+const getElementByXpathParameters = connectionContainerSchema.extend({
+  xpath: z.string().trim().min(1),
+  withWxml: z.boolean().optional().default(false),
+});
+
+const getElementsByXpathParameters = connectionContainerSchema.extend({
+  xpath: z.string().trim().min(1),
+  withWxml: z.boolean().optional().default(false),
+});
+
 export function createPageTools(manager: WeappAutomatorManager): AnyTool[] {
   return [
     createGetElementTool(manager),
     createGetElementsTool(manager),
+    createGetElementByXpathTool(manager),
+    createGetElementsByXpathTool(manager),
     createWaitForElementTool(manager),
     createWaitForTimeoutTool(manager),
     createGetPageDataTool(manager),
@@ -194,6 +206,88 @@ function createGetElementsTool(manager: WeappAutomatorManager): AnyTool {
           return toTextResult(
             formatJson({
               selector: args.selector,
+              count: elements.length,
+              elements: elementsInfo,
+            })
+          );
+        }
+      );
+      }),
+  };
+}
+
+function createGetElementByXpathTool(manager: WeappAutomatorManager): AnyTool {
+  return {
+    name: "page_getElementByXpath",
+    description: "通过 XPath 获取页面第一个匹配元素，相当于 page.getElementByXpath(xpath) / page.xpath(xpath)。适合按文本、层级关系、ancestor/following 等 XPath 表达式定位元素；设置 withWxml 为 true 可额外返回完整 outerWxml。",
+    parameters: getElementByXpathParameters,
+    execute: async (rawArgs, context: ToolContext) =>
+      withUserErrorResult(async () => {
+      const args = getElementByXpathParameters.parse(rawArgs ?? {});
+      return manager.withPage<ContentResult>(
+        context.log,
+        { overrides: args.connection },
+        async (page) => {
+          if (typeof page.getElementByXpath !== "function") {
+            throw new UserError("当前页面不支持 XPath 单元素查询。");
+          }
+
+          const element = await page.getElementByXpath(args.xpath);
+          if (!element) {
+            throw new UserError(`XPath 未找到元素: "${args.xpath}"`);
+          }
+
+          const summary = await summarizeElement(element, {
+            withWxml: args.withWxml,
+          });
+          return toTextResult(
+            formatJson({
+              xpath: args.xpath,
+              ...summary,
+            })
+          );
+        }
+      );
+      }),
+  };
+}
+
+function createGetElementsByXpathTool(manager: WeappAutomatorManager): AnyTool {
+  return {
+    name: "page_getElementsByXpath",
+    description: "通过 XPath 获取页面匹配元素数组，相当于 page.getElementsByXpath(xpath)。适合按文本、属性、层级关系、位置函数等 XPath 表达式批量定位元素；设置 withWxml 为 true 可额外返回每个元素的完整 outerWxml。",
+    parameters: getElementsByXpathParameters,
+    execute: async (rawArgs, context: ToolContext) =>
+      withUserErrorResult(async () => {
+      const args = getElementsByXpathParameters.parse(rawArgs ?? {});
+      return manager.withPage<ContentResult>(
+        context.log,
+        { overrides: args.connection },
+        async (page) => {
+          if (typeof page.getElementsByXpath !== "function") {
+            throw new UserError("当前页面不支持 XPath 元素数组查询。");
+          }
+
+          const elements = await page.getElementsByXpath(args.xpath);
+          if (!Array.isArray(elements)) {
+            throw new UserError(`查询 XPath "${args.xpath}" 失败。`);
+          }
+
+          const elementsInfo = await Promise.all(
+            elements.map(async (el: any, index: number) => {
+              const summary = await summarizeElement(el, {
+                withWxml: args.withWxml,
+              });
+              return {
+                index,
+                ...summary,
+              };
+            })
+          );
+
+          return toTextResult(
+            formatJson({
+              xpath: args.xpath,
               count: elements.length,
               elements: elementsInfo,
             })


### PR DESCRIPTION
## Summary
- add page_getElementByXpath and page_getElementsByXpath MCP tools
- document the new tools in README and allowed-tool examples
- update the inspection prompt to mention XPath query tools

## Validation
- npm run build
- smoke-tested the new tool handlers against the active DevTools session