### PR TITLE
feat: validate selector format in element_getBoundingClientRect

### DIFF
--- a/src/tools/common.ts
+++ b/src/tools/common.ts
@@ -294,3 +294,8 @@ export function parseSelectorWithIndex(selector: string): { baseSelector: string
   }
   return null;
 }
+
+export function isValidIdOrClassSelector(value: string): boolean {
+  const trimmed = value.trim();
+  return trimmed.startsWith("#") || trimmed.startsWith(".");
+}

--- a/src/tools/element.ts
+++ b/src/tools/element.ts
@@ -596,12 +596,19 @@ function createGetAttributesTool(manager: WeappAutomatorManager): AnyTool {
 function createGetBoundingClientRectTool(manager: WeappAutomatorManager): AnyTool {
   return {
     name: "element_getBoundingClientRect",
-    description: "获取元素相对于视口的边界矩形信息（left、top、width、height、right、bottom）。此方法返回的是考虑 CSS transform 变换后的实际渲染尺寸和位置。仅支持 ID 选择器、类选择器。若目标元素位于自定义组件内部，selector 必须指向当前页面 WXML 源码中直接引用的那一层自定义组件，而不是渲染后的组件树；innerSelector 可在 selector 所指组件的整个子树内匹配。",
+    description: "获取元素相对于视口的边界矩形信息（left、top、width、height、right、bottom）。此方法返回的是考虑 CSS transform 变换后的实际渲染尺寸和位置。仅支持 ID 选择器、类选择器。若目标元素位于自定义组件内部，selector 必须使用 ID 选择器指向当前页面 WXML 源码中直接引用的那一层自定义组件，而不是渲染后的组件树；innerSelector 可在 selector 所指组件的整个子树内匹配。",
     parameters: getBoundingClientRectParameters,
     execute: async (rawArgs, context: ToolContext) =>
       withUserErrorResult(async () => {
       const args = getBoundingClientRectParameters.parse(rawArgs ?? {});
       const { selector, innerSelector } = args;
+
+      if (!selector.startsWith("#") && !selector.startsWith(".")) {
+        throw new UserError("selector 仅支持 ID 选择器 (以 '#' 开头) 或类选择器 (以 '.' 开头)。若需选择页面内自定义组件，请保证代码对组件赋值了 ID 并使用 ID 选择器。");
+      }
+      if (innerSelector && !innerSelector.startsWith("#") && !innerSelector.startsWith(".")) {
+        throw new UserError("innerSelector 仅支持 ID 选择器 (以 '#' 开头) 或类选择器 (以 '.' 开头)");
+      }
 
       return manager.withMiniProgram(
         context.log,

--- a/src/tools/element.ts
+++ b/src/tools/element.ts
@@ -14,6 +14,7 @@ import {
   waitOnPage,
   parseSelectorWithIndex,
   withUserErrorResult,
+  isValidIdOrClassSelector,
 } from "./common.js";
 
 const tapElementParameters = connectionContainerSchema.extend({
@@ -596,18 +597,18 @@ function createGetAttributesTool(manager: WeappAutomatorManager): AnyTool {
 function createGetBoundingClientRectTool(manager: WeappAutomatorManager): AnyTool {
   return {
     name: "element_getBoundingClientRect",
-    description: "获取元素相对于视口的边界矩形信息（left、top、width、height、right、bottom）。此方法返回的是考虑 CSS transform 变换后的实际渲染尺寸和位置。仅支持 ID 选择器、类选择器。若目标元素位于自定义组件内部，selector 必须使用 ID 选择器指向当前页面 WXML 源码中直接引用的那一层自定义组件，而不是渲染后的组件树；innerSelector 可在 selector 所指组件的整个子树内匹配。",
+    description: "获取元素相对于视口的边界矩形信息（left、top、width、height、right、bottom）。此方法返回的是考虑 CSS transform 变换后的实际渲染尺寸和位置。仅支持 ID 选择器、类选择器。若目标元素位于自定义组件内部，selector 必须指向当前页面 WXML 源码中直接引用的那一层自定义组件，而不是渲染后的组件树；innerSelector 可在 selector 所指组件的整个子树内匹配。",
     parameters: getBoundingClientRectParameters,
     execute: async (rawArgs, context: ToolContext) =>
       withUserErrorResult(async () => {
       const args = getBoundingClientRectParameters.parse(rawArgs ?? {});
       const { selector, innerSelector } = args;
 
-      if (!selector.startsWith("#") && !selector.startsWith(".")) {
-        throw new UserError("selector 仅支持 ID 选择器 (以 '#' 开头) 或类选择器 (以 '.' 开头)。若需选择页面内自定义组件，请保证代码对组件赋值了 ID 并使用 ID 选择器。");
+      if (!isValidIdOrClassSelector(selector)) {
+        throw new UserError("selector 仅支持 ID 选择器 (以 '#' 开头) 或类选择器 (以 '.' 开头)。若需选择自定义组件，请保证代码对组件赋值了 id 并使用 id 选择器。");
       }
-      if (innerSelector && !innerSelector.startsWith("#") && !innerSelector.startsWith(".")) {
-        throw new UserError("innerSelector 仅支持 ID 选择器 (以 '#' 开头) 或类选择器 (以 '.' 开头)");
+      if (innerSelector && !isValidIdOrClassSelector(innerSelector)) {
+        throw new UserError("innerSelector 仅支持 ID 选择器 (以 '#' 开头) 或类选择器 (以 '.' 开头)。");
       }
 
       return manager.withMiniProgram(

--- a/src/tools/element.ts
+++ b/src/tools/element.ts
@@ -605,7 +605,7 @@ function createGetBoundingClientRectTool(manager: WeappAutomatorManager): AnyToo
       const { selector, innerSelector } = args;
 
       if (!isValidIdOrClassSelector(selector)) {
-        throw new UserError("selector 仅支持 ID 选择器 (以 '#' 开头) 或类选择器 (以 '.' 开头)。若需选择自定义组件，请保证代码对组件赋值了 id 并使用 id 选择器。");
+        throw new UserError("selector 仅支持 ID 选择器 (以 '#' 开头) 或类选择器 (以 '.' 开头)。若目标元素位于自定义组件内部，selector 必须指向当前页面 WXML 源码中直接引用的那一层自定义组件，而不是渲染后的组件树。");
       }
       if (innerSelector && !isValidIdOrClassSelector(innerSelector)) {
         throw new UserError("innerSelector 仅支持 ID 选择器 (以 '#' 开头) 或类选择器 (以 '.' 开头)。");


### PR DESCRIPTION
Validate that selector and innerSelector start with '#' or '.' in element_getBoundingClientRect. Additionally, add a reminder to assign an id to custom components if they need to be selected.